### PR TITLE
Initial ezid ark support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Currently, the following Minters are available:
 
 * [Handle](modules/hdl) (contributed by [@elizoller](https://github.com/elizoller))
 * [DataCite DOI Minter](modules/doi_datacite/README.md)
+* [EZID ARKs](modules/ezid) (contributed by [@seth-shaw-unlv](https://github.com/seth-shaw-unlv))
 
 The following Persisters are available:
 

--- a/modules/ezid/config/install/ezid.settings.yml
+++ b/modules/ezid/config/install/ezid.settings.yml
@@ -1,0 +1,3 @@
+ezid_user: apitest
+ezid_shoulder: ark:/99999/fk4
+ezid_api_endpoint: https://ezid.cdlib.org

--- a/modules/ezid/config/install/system.action.ezid_mint_ark.yml
+++ b/modules/ezid/config/install/system.action.ezid_mint_ark.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: ezid_mint_ark
+label: 'Mint ARK with EZID'
+type: node
+plugin: ezid_mint_ark
+configuration: {  }

--- a/modules/ezid/ezid.info.yml
+++ b/modules/ezid/ezid.info.yml
@@ -1,0 +1,7 @@
+name: 'EZID (ARK) Persistent ID Minter'
+description: "A minter accompanying the Persistent Identifers module for minting ARKs using EZID."
+type: module
+core: 8.x
+core_version_requirement: ^8 || ^9
+dependencies:
+ - persistent_identifiers

--- a/modules/ezid/ezid.module
+++ b/modules/ezid/ezid.module
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * @file
+ * Contains the ezid.module.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_alter().
+ */
+function ezid_form_alter(&$form, FormStateInterface &$form_state, $form_id) {
+  if ($form_id == 'persistent_identifiers_admin_settings') {
+    $config = \Drupal::config('ezid.settings');
+    $form['ezid_user'] = [
+      '#type' => 'textfield',
+      '#access' => TRUE,
+      '#title' => 'EZID Username',
+      '#default_value' => $config->get('ezid_user'),
+      '#states' => [
+        'visible' => [
+          ':input[id="persistent_identifiers_minter"]' => ['value' => 'ezid.minter.ezid'],
+        ],
+      ],
+    ];
+
+    $form['ezid_password'] = [
+      '#type' => 'password',
+      '#title' => 'EZID Password',
+      '#description' => t("The password used to authenticate for the API. Leave blank to make no changes, use an invalid string to disable if need be."),
+      '#states' => [
+        'visible' => [
+          ':input[id="persistent_identifiers_minter"]' => ['value' => 'ezid.minter.ezid'],
+        ],
+      ],
+    ];
+
+    $form['ezid_api_endpoint'] = [
+      '#type' => 'textfield',
+      '#access' => TRUE,
+      '#title' => 'EZID API Endpoint',
+      '#default_value' => $config->get('ezid_api_endpoint'),
+      '#description' => t("The API endpoint for EZID (probably won't change)."),
+      '#states' => [
+        'visible' => [
+          ':input[id="persistent_identifiers_minter"]' => ['value' => 'ezid.minter.ezid'],
+        ],
+      ],
+    ];
+
+    $form['ezid_shoulder'] = [
+      '#type' => 'textfield',
+      '#access' => TRUE,
+      '#title' => 'Namespace (shoulder)',
+      '#default_value' => $config->get('ezid_shoulder'),
+      '#description' => t("The NAAN namespace used for minting ARKs. E.g. 'ark:/99999/fk4cz3dh0'."),
+      '#states' => [
+        'visible' => [
+          ':input[id="persistent_identifiers_minter"]' => ['value' => 'ezid.minter.ezid'],
+        ],
+      ],
+    ];
+
+    // @TODO Add mapping options for metadata per bundle.
+    $form['#submit'][] = 'ezid_submit';
+  }
+}
+
+/**
+ * Submit callback.
+ *
+ * Saves the value of the minter-specific field defined in the implementation
+ * of hook_form_alter() above.
+ *
+ * @param array $form
+ *   The form.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ */
+function ezid_submit(array &$form, FormStateInterface $form_state) {
+  $existing_config = \Drupal::config('ezid.settings');
+  $ezid_user = $form_state->getValue('ezid_user', $existing_config->get('ezid_user'));
+  $password = $form_state->getValue('ezid_password', $existing_config->get('ezid_password'));
+
+  $ezid_api_endpoint = $form_state->getValue('ezid_api_endpoint', $existing_config->get('ezid_api_endpoint'));
+  $ezid_shoulder = $form_state->getValue('ezid_shoulder', $existing_config->get('ezid_shoulder'));
+
+  // Save password in Drupal state.
+  $state = \Drupal::state();
+  if (!empty($form_state->getValue('ezid_password'))) {
+    $state->set('ezid.password', $form_state->getValue('ezid_password'));
+  }
+
+  $config_factory = \Drupal::configFactory();
+  $config_factory->getEditable('ezid.settings')
+    ->set('ezid_user', trim($ezid_user))
+    ->set('ezid_api_endpoint', trim($ezid_api_endpoint))
+    ->set('ezid_shoulder', trim($ezid_shoulder))
+    ->save();
+}

--- a/modules/ezid/ezid.services.yml
+++ b/modules/ezid/ezid.services.yml
@@ -1,0 +1,5 @@
+services:
+  # The list of minters at /admin/config/persistent_identifiers/settings is derived
+  # from minters that follow this naming pattern.
+  ezid.minter.ezid:
+    class: Drupal\ezid\Minter\Ezid

--- a/modules/ezid/src/Minter/Ezid.php
+++ b/modules/ezid/src/Minter/Ezid.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Drupal\ezid\Minter;
+
+use Psr7\Message;
+use Drupal\persistent_identifiers\MinterInterface;
+use GuzzleHttp\Exception\RequestException;
+
+/**
+ * A Handle class.
+ *
+ * Mints a persistent identifier using a configurable
+ * namespace and a random string.
+ */
+class Ezid implements MinterInterface {
+
+  /**
+   * Returns the minter's name.
+   *
+   * @return string
+   *   Appears in the Persistent Identifiers config form.
+   */
+  public function getName() {
+    return t('EZID ARK Minter');
+  }
+
+  /**
+   * Returns the minter's type.
+   *
+   * @return string
+   *   Appears in the entity edit form next to the checkbox.
+   */
+  public function getPidType() {
+    return t('ARK');
+  }
+
+  /**
+   * Mints the identifier.
+   *
+   * Issues a mint request to the EZID service for an ARK.
+   *
+   * @param object $entity
+   *   The entity.
+   * @param mixed $extra
+   *   Extra data the minter needs, for example from the node edit form.
+   *
+   * @return string
+   *   The identifier.
+   */
+  public function mint($entity, $extra = NULL) {
+    $password = \Drupal::state()->get('ezid.password');
+
+    $config = \Drupal::config('ezid.settings');
+    $ezid_user = $config->get('ezid_user');
+    $ezid_api_endpoint = $config->get('ezid_api_endpoint');
+    $ezid_shoulder = $config->get('ezid_shoulder');
+
+    $host = \Drupal::request()->getSchemeAndHttpHost();
+    $target = $host . $entity->toUrl()->toString();
+
+    // @TODO Add support for Dublin Core and additional fields based on bundle.
+    $data = "_profile: erc\n";
+    $data = $data . "what: " . $entity->label() . "\n";
+    $data = $data . "_target: $target\n";
+
+    $client = \Drupal::httpClient();
+    try {
+      $request = $client->request(
+        'POST',
+        $ezid_api_endpoint . '/shoulder/' . $ezid_shoulder,
+        [
+          'auth' => [$ezid_user, $password],
+          'headers' => ['Content-Type' => 'text/plain; charset=UTF-8'],
+          'body' => $data,
+        ]);
+      \Drupal::logger('persistent identifiers')->info(print_r($request, TRUE));
+      $message = $request->getBody();
+      if (strpos($message, "success: ") === 0) {
+        return substr($message, 9);
+      }
+      \Drupal::logger('persistent identifiers')->error("Could not mint: $message");
+      return FALSE;
+    }
+    catch (RequestException $e) {
+      $message = Message::toString($e->getRequest());
+      if ($e->hasResponse()) {
+        $message = $message . "\n" . Message::toString($e->getResponse());
+      }
+      \Drupal::logger('persistent identifiers')->error(preg_replace('/Authorization: Basic \w+/', 'Authentication Redacted', $message));
+      return FALSE;
+    }
+  }
+
+}

--- a/modules/ezid/src/Plugin/Action/MintEzidAction.php
+++ b/modules/ezid/src/Plugin/Action/MintEzidAction.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Drupal\ezid\Plugin\Action;
+
+use Drupal\Core\Action\ActionBase;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Mints ARKs via EZID.
+ *
+ * @Action(
+ *   id = "ezid_mint_ark",
+ *   label = @Translation("Mint EZID Ark"),
+ *   type = "",
+ *   confirm = TRUE,
+ * )
+ */
+class MintEzidAction extends ActionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute($entity = NULL) {
+    $minter = \Drupal::service('ezid.minter.ezid');
+    $persister_id = \Drupal::config('persistent_identifiers.settings')->get('persistent_identifiers_persister');
+    $persister = \Drupal::service($persister_id);
+    // The values saved in this action's configuration form
+    // are in $this->configuration.
+    $ark = $minter->mint($entity, $this->configuration);
+
+    if (strlen($ark)) {
+      $persister->persist($entity, $ark);
+      $this->messenger()->addMessage('"' . $entity->label() . '" assigned ' . $ark);
+    }
+    else {
+      $this->messenger()->addMessage('"' . $entity->label() . '" (node ' . $entity->id() . ') not assigned an ARK. See system log for details.');
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
+    /** @var \Drupal\node\NodeInterface $object */
+    $result = $object->access('edit', $account, TRUE)
+      ->andIf($object->access('update', $account, TRUE));
+
+    return $return_as_object ? $result : $result->isAllowed();
+  }
+
+}


### PR DESCRIPTION
Provides EZID-based ARK support. Although not fully satisfying #11, it does for those subscribed to that [California Digital Library's EZID service](https://ezid.cdlib.org/).

To test minting you can [request the password to their test account](https://ezid.cdlib.org/doc/apidoc.html#testing-the-api).

It could be improved by adding additional fields to populate the EZID service's ARK metadata, but this works well enough for a start.