### PR TITLE
Ezid improvements

### DIFF
--- a/modules/ezid/src/Minter/Ezid.php
+++ b/modules/ezid/src/Minter/Ezid.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\ezid\Minter;
 
-use Psr7\Message;
 use Drupal\persistent_identifiers\MinterInterface;
 use GuzzleHttp\Exception\RequestException;
 
@@ -73,7 +72,6 @@ class Ezid implements MinterInterface {
           'headers' => ['Content-Type' => 'text/plain; charset=UTF-8'],
           'body' => $data,
         ]);
-      \Drupal::logger('persistent identifiers')->info(print_r($request, TRUE));
       $message = $request->getBody();
       if (strpos($message, "success: ") === 0) {
         return substr($message, 9);
@@ -82,9 +80,9 @@ class Ezid implements MinterInterface {
       return FALSE;
     }
     catch (RequestException $e) {
-      $message = Message::toString($e->getRequest());
+      $message = $e->getRequest()->getUri();
       if ($e->hasResponse()) {
-        $message = $message . "\n" . Message::toString($e->getResponse());
+        $message .= "\n" . $e->getResponse()->getBody();
       }
       \Drupal::logger('persistent identifiers')->error(preg_replace('/Authorization: Basic \w+/', 'Authentication Redacted', $message));
       return FALSE;

--- a/persistent_identifiers.module
+++ b/persistent_identifiers.module
@@ -89,18 +89,21 @@ function persistent_identifiers_jsonld_alter_normalized_array(EntityInterface $e
     $doi_field_name = $config->get('persistent_identifiers_target_field');
     if ($entity->hasField($doi_field_name)) {
       $doi_field_values = $entity->get($doi_field_name)->getValue();
-      if (array_key_exists('value', $doi_field_values[0])) {
-        $doi = $doi_field_values[0]['value'];
-      }
+      $identifiers = array_filter(array_map(
+        fn($value): string => (isset($value['value'])) ? $value['value'] : "",
+        $doi_field_values
+      ));
     }
 
     if (isset($normalized['@graph'])) {
-      if (strlen($doi) && !is_array($normalized["@graph"])) {
-        $normalized['@graph'] = [$normalized['@graph']];
+      foreach ($identifiers as $id) {
+        if (strlen($id) && !is_array($normalized["@graph"])) {
+          $normalized['@graph'] = [$normalized['@graph']];
+        }
+        $normalized['@graph'][0]['http://schema.org/sameAs'][] = [
+          '@id'  => $resolver_base_url . $id,
+        ];
       }
-      $normalized['@graph'][0]['http://schema.org/sameAs'][] = [
-        '@id'  => $resolver_base_url . $doi,
-      ];
     }
   }
 }

--- a/src/Plugin/Form/PersistentIdentifiersSettingsForm.php
+++ b/src/Plugin/Form/PersistentIdentifiersSettingsForm.php
@@ -84,7 +84,7 @@ class PersistentIdentifiersSettingsForm extends ConfigFormBase {
       '#weight' => 100,
       '#type' => 'checkbox',
       '#default_value' => $config->get('persistent_identifiers_map_to_schema_sameas'),
-      '#description' => $this->t("Add the persistent identifier to the node's JSON-LD as schema:sameAs, prepending the URL configured below. If the field is multivalued, uses the first value."),
+      '#description' => $this->t("Add the persistent identifier to the node's JSON-LD as schema:sameAs, prepending the URL configured below."),
       '#title' => $this->t('Map to schema:sameAs in JSON-LD'),
       '#attributes' => [
         'id' => 'persistent_identifiers_map_to_schema_sameas',


### PR DESCRIPTION
First, the EZID minter was not working with Drupal 9 as it couldn't find the Psr7\Message class.

Second, in the case where a persistent identifier field has multiple values, we were only serializing the first one in JSONLD. This update serializes all the values of a multi-valued identifier field.